### PR TITLE
Added commands and packages for Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ NODEJS=nodejs
 JASMIN=jasmin
 
 ifeq ($(shell [ -f /etc/arch-release ] && echo arch),arch)
-	BRAINFUCK=brainfuck
-	CLOJURE=clj
-	NODEJS=node
-	JASMIN=java -jar jasmin.jar
+  BRAINFUCK=brainfuck
+  CLOJURE=clj
+  NODEJS=node
+  JASMIN=java -jar jasmin.jar
 endif
 
 all: QR2.rb

--- a/src/Makefile.gen.rb
+++ b/src/Makefile.gen.rb
@@ -2,8 +2,8 @@ require_relative "code-gen"
 
 OUT = []
 
-def banner(s)
-  s = "##  #{ s }  ##"
+def banner(s1, s2=nil)
+  s = "##  #{ s1 }#{ ' -> ' + s2 if s2 }  ##"
   OUT << "\t@echo"
   OUT << "\t@echo \"#{ "#" * s.size }\""
   OUT << "\t@echo \"#{ s }\""
@@ -11,8 +11,21 @@ def banner(s)
   OUT << "\t@echo"
 end
 
-OUT << "MAKEFLAGS += --no-print-directory"
-OUT << ""
+OUT << <<-END
+MAKEFLAGS += --no-print-directory
+
+BRAINFUCK=beef
+CLOJURE=clojure
+NODEJS=nodejs
+JASMIN=jasmin
+
+ifeq ($(shell [ -f /etc/arch-release ] && echo arch),arch)
+  BRAINFUCK=brainfuck
+  CLOJURE=clj
+  NODEJS=node
+  JASMIN=java -jar jasmin.jar
+endif
+END
 OUT << "all: QR2.rb"
 banner("CHECK")
 OUT << "\tdiff QR.rb QR2.rb"
@@ -21,12 +34,20 @@ langs = CodeGen::List.reverse.flat_map {|c| c.steps.map {|step| step.name } } + 
 cmds = CodeGen::List.reverse.flat_map {|c| c.steps.map {|step| step.cmd } }
 srcs = CodeGen::List.reverse.flat_map {|c| c.steps.map {|step| step.src } } + ["QR2.rb"]
 
+cmds.each {|cmd|
+  cmd.gsub!(/^(beef|clojure|nodejs|jasmin)/,
+    'beef' => '$(BRAINFUCK)',
+    'clojure' => '$(CLOJURE)',
+    'nodejs' => '$(NODEJS)',
+    'jasmin' => '$(JASMIN)')
+}
+
 cmds.size.times do |i|
   cmd = cmds[i].gsub("OUTFILE", srcs[i + 1])
 
   OUT << ""
   OUT << "#{ srcs[i + 1] }: #{ srcs[i] }"
-  banner(langs[i] + " -> " + langs[i + 1])
+  banner(langs[i], langs[i + 1])
   cmd.split("&&").each {|c| OUT << "\t" + c.strip }
 end
 

--- a/src/README.md.gen.rb
+++ b/src/README.md.gen.rb
@@ -11,7 +11,7 @@ rows = [["language", "ubuntu package", "version"]]
 rows += (langs.zip(apts) + [["(extra)", "tcc"]]).map do |lang, apt|
     if apt
       pkg = `dpkg -p #{ apt }`
-      version = $?.exitstatus > 0 && pkg.b[/^Version: (.*)/, 1]
+      version = $?.success? && pkg.b[/^Version: (.*)/, 1]
     end
     [lang, apt || "(none)", version || '-']
   end
@@ -26,31 +26,6 @@ apt_get = "sudo apt-get install #{ (apts + ["tcc"]).compact.uniq.sort * " " }"
 apt_get.gsub!(/.{,70}( |\z)/) do
   $&[-1] == " " ? $& + "\\\n      " : $&
 end
-
-pacman_apts = %w(bash boo clisp clojure fpc gawk gcc gcc-fortran ghc go gprolog
-  groovy llvm make mono nodejs ocaml octave parrot perl php python r ruby scala
-  tcl).compact.uniq.sort
-
-pacman = "pacman -S --needed #{ pacman_apts * " " }"
-pacman.gsub!(/.{,70}( |\z)/) do
-  $&[-1] == " " ? $& + "\\\n      " : $&
-end
-
-yaourt_apts = %w(algol68genie coffee-script c-intercal f2c gauche gforth icon
-  iverilog open-cobol rpl pike regina-rexx-das swi-prolog ucblogo vala
-).compact.uniq.sort
-
-yaourt = "yaourt -S #{ yaourt_apts * " " }"
-yaourt.gsub!(/.{,70}( |\z)/) do
-  $&[-1] == " " ? $& + "\\\n      " : $&
-end
-
-missing = {
-  jasmin: 'http://sourceforge.net/projects/jasmin/files/jasmin/',
-  pike: 'http://packages.ubuntu.com/en/raring/ucblogo',
-  ucblogo: 'http://packages.ubuntu.com/raring/pike7.8-core',
-}.map {|k, v| "[`#{ k }`](#{ v })" }
-missing[-1] = missing[-2] + " and " + missing.pop if missing.size > 1
 
 cmds = cmds.zip(srcs.drop(1) + ["QR.rb"]).map do |cmd, src|
   cmd.gsub("OUTFILE", src).gsub(/mv QR\.c(\.bak)? QR\.c(\.bak)? && /, "")
@@ -85,12 +60,7 @@ You just have to type the following apt-get command to install all of them.
 
     $ <%= apt_get %>
 
-You can also install languages from Arch Linux's repositories and AUR,
-except <%= missing * ', ' %>, which may not work properly.
-Note: `yaourt` has `--noconfirm` option.
-
-    # <%= pacman %>
-    # <%= yaourt %>
+You may find [instructions for Arch Linux and other platforms in the wiki](https://github.com/mame/quine-relay/wiki/Installation).
 
 If you are not using these Linux distributions, please find your way yourself.
 If you could do it, please let me know.  Good luck.


### PR DESCRIPTION
Three packages are missing. Information is included, but their installation could be automatized:

```
# yaourt -S dpkg java-runtime
# TMP=$(mktemp -d)
# cwd=$(pwd)
# cd $TMP
# wget -O ucblogo.deb http://ubuntu.mirror.cambrium.nl/ubuntu//pool/universe/u/ucblogo/ucblogo_5.5-2.1_amd64.deb
# wget -O jasmin.zip http://sourceforge.net/projects/jasmin/files/jasmin/jasmin-2.4/jasmin-2.4.zip/download
# wget -O pike.deb http://ubuntu.mirror.cambrium.nl/ubuntu//pool/universe/p/pike7.8/pike7.8-core_7.8.352-dfsg-7ubuntu1_amd64.deb
# unzip jasmin.zip
# cp jasmin-2.4/jasmin.jar $cwd/
# dpkg -i --force-depends pike.deb ucblogo.deb
```

Need to rebuild
