### PR TITLE
Using Bash to check the executable name of Node.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
 MAKEFLAGS += --no-print-directory
 
-NODE := $(shell which nodejs)
+NODE := $(shell which nodejs 2>/dev/null || which node)
 ifeq ($(NODE),)
-  NODE := $(shell which node)
-  ifeq ($(NODE),)
-    $(warning No node found!)
-  endif
+  $(warning Node.js not found!)
 endif
-  
+
 .DELETE_ON_ERROR:
 
 

--- a/src/Makefile.gen.rb
+++ b/src/Makefile.gen.rb
@@ -14,14 +14,11 @@ end
 OUT << <<-END
 MAKEFLAGS += --no-print-directory
 
-NODE := $(shell which nodejs)
+NODE := $(shell which nodejs 2>/dev/null || which node)
 ifeq ($(NODE),)
-  NODE := $(shell which node)
-  ifeq ($(NODE),)
-    $(warning No node found!)
-  endif
+  $(warning Node.js not found!)
 endif
-  
+
 .DELETE_ON_ERROR:
 
 END


### PR DESCRIPTION
It's possible to use Bash only, but that could be too much

```
NODE := $(shell which nodejs 2>/dev/null || which node || echo Node.js not found! >&2)
```
