### PR TITLE
With these changes, the full chain works on Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,12 @@ NODE := $(shell which nodejs 2>/dev/null || which node)
 ifeq ($(NODE),)
   $(warning Node.js not found!)
 endif
-SCHEME := $(shell which guile 2>/dev/null || which gosh 2>/dev/null || which csi >/dev/null && echo "csi -s" )
+SCHEME := $(shell which guile csi gosh 2>/dev/null | head -1)
 ifeq ($(SCHEME),)
   $(warning Scheme interpreter not found!)
+endif
+ifeq ($(SCHEME),$(shell which csi 2>/dev/null | head -1))
+  SCHEME := csi -s
 endif
 
 .DELETE_ON_ERROR:


### PR DESCRIPTION
Improved the scheme detection somewhat and added a check for adding '-s' if the scheme used is csi (chicken).

Added a logo script that will only be used if /usr/bin/logo.real exists. It's not perfect, but it will work also if the Arch Linux ucblogo package is updated in the future, and can then be removed.

Finally, the full chain works on Arch Linux!

``` bash
#############
##  CHECK  ##
#############

diff QR.rb QR2.rb
[alexander@vzap quine-relay]$ echo $?
0
```
