### PR TITLE
Remove a warning message from cobc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -445,3 +445,8 @@ QR2.rb: QR.rexx
 	@echo "####################"
 	@echo
 	rexx ./QR.rexx > QR2.rb
+
+clean:
+	@mv QR.rb quine-relay.rb
+	rm -f qr QR qr.* QR.* QR2.rb *.class
+	@mv quine-relay.rb QR.rb


### PR DESCRIPTION
When compiled with `_FORTIFY_SOURCE` (default for Arch Linux), but not with optimization enabled, cobc outputs a warning message. Adding -O2 removes this message and should be fine for other cases as well.
