### PR TITLE
Add -lm to avoid "undefined reference to 'sinh'"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ QR.f90: QR.f
 	@echo
 	mv QR.c QR.c.bak
 	f2c QR.f
-	${CC} -o QR QR.c -L/usr/lib -lf2c
+	${CC} -o QR QR.c -L/usr/lib -lf2c -lm
 	mv QR.c.bak QR.c
 	./QR > QR.f90
 


### PR DESCRIPTION
Hi,

When compiling the resulting C code from F2C, I get "undefined reference to `sinh'", amongst others (about 20 math-related functions can't be found). Adding`-lm` links with the math library and solves this.

Best regards,
Alexander F Rødseth / xyproto
