### PR TITLE
Fixing strange problems with R and case in filenames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -850,21 +850,21 @@ QR.R: QR.py
 	@echo
 	python QR.py > QR.R
 
-QR.r: QR.R
+QR.ra: QR.R
 	@echo
 	@echo "#######################"
 	@echo "##  98: R -> Ratfor  ##"
 	@echo "#######################"
 	@echo
-	R --slave -f QR.R > QR.r
+	R --slave -f QR.R > QR.ra
 
-QR.rexx: QR.r
+QR.rexx: QR.ra
 	@echo
 	@echo "##########################"
 	@echo "##  99: Ratfor -> REXX  ##"
 	@echo "##########################"
 	@echo
-	ratfor -o QR.r.f QR.r
+	ratfor -o QR.r.f QR.ra
 	gfortran -o QR QR.r.f
 	./QR > QR.rexx
 


### PR DESCRIPTION
R v3.1.2 (from Ubuntu 15.04) behaves very strange and it seems make no difference between "QR.r" and "QR.R" files.
On my system it gives:
```
root@vagrant-ubuntu-vivid-32:/vagrant/qr# python QR.py > QR.R
root@vagrant-ubuntu-vivid-32:/vagrant/qr# ls -al QR.R
-rw-r--r-- 1 vagrant vagrant 310436 May 16 12:55 QR.R
root@vagrant-ubuntu-vivid-32:/vagrant/qr# R --slave -f QR.R > QR.r
root@vagrant-ubuntu-vivid-32:/vagrant/qr# ls -al QR.R QR.r
-rw-r--r-- 1 vagrant vagrant 0 May 16 12:55 QR.r
-rw-r--r-- 1 vagrant vagrant 0 May 16 12:55 QR.R
```
i.e. it deletes both files. Renaming QR.r to QR.ra helps -
```
root@vagrant-ubuntu-vivid-32:/vagrant/qr# python QR.py > QR.R
root@vagrant-ubuntu-vivid-32:/vagrant/qr# ls -al QR.R
-rw-r--r-- 1 vagrant vagrant 310436 May 16 12:57 QR.R
root@vagrant-ubuntu-vivid-32:/vagrant/qr# R --slave -f QR.R > QR.ra
root@vagrant-ubuntu-vivid-32:/vagrant/qr# ls -al QR.R QR.ra
-rw-r--r-- 1 vagrant vagrant 310436 May 16 12:57 QR.R
-rw-r--r-- 1 vagrant vagrant 212164 May 16 12:57 QR.ra
```