### PR TITLE
Whitespace heap cells fix.

### DIFF
--- a/vendor/whitespace.rb
+++ b/vendor/whitespace.rb
@@ -40,7 +40,7 @@ File.read($*[0]).gsub(/[^ \t\n]/m, "").tr(" \t\n", "012").scan(RE) do
   insn == :mark ? labels[arg] = code.size : code << [insn, arg]
 end
 
-pc, call, stack, heap = 0, [], [], {}
+pc, call, stack, heap = 0, [], [], Hash.new(0)
 loop do
   insn, arg = code[pc]
   pc += 1


### PR DESCRIPTION
They don't have to be written to before they are used.

You prompted me to do a full set of tests on my interpreter (and yours came along for the ride).
Ruby returns (nil) for heap cells that haven't been written to, this errors on your interpreter, but not the reference one. This also seems to impact a brainfuck interpreter written in whitespace (from [Vii5ard](https://github.com/vii5ard/brainfuck-whitespace)).

The test program is a "Hello World" done in a very complicated manner.

```
diff -urd ws.wspace-0.3/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.err ws.whitespace.rb/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.err
--- ws.wspace-0.3/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.err       2015-08-21 20:34:18.683490694 +0100
+++ ws.whitespace.rb/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.err    2015-08-21 20:33:38.375822010 +0100
@@ -0,0 +1,3 @@
+./whitespace.rb:58:in `block in <main>': undefined method `*' for nil:NilClass (NoMethodError)
+       from ./whitespace.rb:46:in `loop'
+       from ./whitespace.rb:46:in `<main>'
diff -urd ws.wspace-0.3/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.res ws.whitespace.rb/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.res
--- ws.wspace-0.3/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.res       2015-08-21 20:34:18.687490661 +0100
+++ ws.whitespace.rb/d9196318dc15f0dbcbf1bb9edcc4d5ad.ws.res    2015-08-21 20:33:38.379821978 +0100
@@ -1 +1 @@
-Hello World!
+H
```

```
00010000110020000211000010000001020001001000212000200001001000211000010210000200
00121100001210000200001021100001210000200001021100001210000200001121102001202011
12101020001210000201110000202111000012100002002011100002111000112100210001100011
02100002002011100002111000112100210001100001210000200000211000110210002021220010
20001210000200201110011012100011002011112000001021000020020111000112100011002011
11200020111120002002011100011210001100201111200000121000020020111001121000110020
11112000011021000200112020111210100200012100020010120201112101102020020111000121
00011000012100002002011100012100011020210122001102000102100020211220010020011210
00020020111001111021000110020111120000010210000201111200020020111000112100011002
01111200020020111001110210001100201111200020020111001100021000110020111120000012
10000200201110001210001100201111200000121000020020111000121000110020111120002222
2
```