### PR TITLE
Add curl to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ First, you have to type the following apt-get command to install all of them.
 
 Then, build the bundled interpreters.
 
-    $ sudo apt-get install libpng-dev libgd-dev groff flex bison
+    $ sudo apt-get install libpng-dev libgd-dev groff flex bison curl
     $ make -C vendor
 
 #### 2. Run each program on each interpreter/compiler.


### PR DESCRIPTION
The golfscript installation in vendor/Makefile requires curl, but it does not seem to be installed by default on Ubuntu 19.10, nor does it seem to be pulled in by any of the other packages currently listed in the instructions.