### PR TITLE
Improve README and minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /qr*
 /tmp
 /nimcache
+/.curry
 !QR.rb
 gst.im
 /src/lazyk-boot.dat

--- a/Makefile
+++ b/Makefile
@@ -820,8 +820,10 @@ QR.ls: qr.li
 	@echo "##  93: Lisaac -> LiveScript  ##"
 	@echo "################################"
 	@echo
+	@mv QR.c QR.c.bak
 	lisaac qr.li
 	./qr > QR.ls
+	@mv QR.c.bak QR.c
 
 QR.ll: QR.ls
 	@echo
@@ -880,9 +882,9 @@ QR.mzn: QR.mac
 	@echo "##  100: Maxima -> MiniZinc  ##"
 	@echo "###############################"
 	@echo
-	@if [ $(CI) = "true" ]; then mv /tmp /tmp.bak && ln -s /dev/shm /tmp; fi
+	@if [ "$(CI)" = "true" ]; then mv /tmp /tmp.bak && ln -s /dev/shm /tmp; fi
 	maxima -q --init-mac=QR.mac > QR.mzn
-	@if [ $(CI) = "true" ]; then rm /tmp && mv /tmp.bak /tmp; fi
+	@if [ "$(CI)" = "true" ]; then rm /tmp && mv /tmp.bak /tmp; fi
 
 QR.il: QR.mzn
 	@echo

--- a/README.md
+++ b/README.md
@@ -195,6 +195,19 @@ Alternatively, just type `make`.
 
 Note: It may require huge memory to compile some files.
 
+### Docker
+
+Simply build the image and run a container as follows:
+
+    $ docker build -t qr .
+    $ docker run --privileged --rm -e CI=true qr
+
+Note: you need to run in privileged mode otherwise the `maxima` command will fail.
+
+If you want to check generated files, you can mount the local directory in the Docker container (but keep using the `vendor` directory of the container), as follows:
+
+    $ docker run --privileged --rm -e CI=true -v /Users/antoinechoppin/dev/github/quine-relay:/usr/local/share/quine-relay -v /usr/local/share/quine-relay/vendor qr
+
 ### Other platforms
 
 You may find [instructions for other platforms in the wiki](https://github.com/mame/quine-relay/wiki/Installation).

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Note: you need to run in privileged mode otherwise the `maxima` command will fai
 
 If you want to check generated files, you can mount the local directory in the Docker container (but keep using the `vendor` directory of the container), as follows:
 
-    $ docker run --privileged --rm -e CI=true -v /Users/antoinechoppin/dev/github/quine-relay:/usr/local/share/quine-relay -v /usr/local/share/quine-relay/vendor qr
+    $ docker run --privileged --rm -e CI=true -v $(pwd):/usr/local/share/quine-relay -v /usr/local/share/quine-relay/vendor qr
 
 ### Other platforms
 

--- a/src/README.md.gen.rb
+++ b/src/README.md.gen.rb
@@ -109,6 +109,19 @@ Alternatively, just type `make`.
 
 Note: It may require huge memory to compile some files.
 
+### Docker
+
+Simply build the image and run a container as follows:
+
+    $ docker build -t qr .
+    $ docker run --privileged --rm -e CI=true qr
+
+Note: you need to run in privileged mode otherwise the `maxima` command will fail.
+
+If you want to check generated files, you can mount the local directory in the Docker container (but keep using the `vendor` directory of the container), as follows:
+
+    $ docker run --privileged --rm -e CI=true -v $(pwd):/usr/local/share/quine-relay -v /usr/local/share/quine-relay/vendor qr
+
 ### Other platforms
 
 You may find [instructions for other platforms in the wiki](https://github.com/mame/quine-relay/wiki/Installation).

--- a/src/code-gen.rb
+++ b/src/code-gen.rb
@@ -358,8 +358,8 @@ class Maxima < CodeGen
   Cmd = "maxima -q --init-mac=QR.mac > OUTFILE"
   Apt = "maxima"
   Backup = [[
-    %(if [ $(CI) = "true" ]; then mv /tmp /tmp.bak && ln -s /dev/shm /tmp; fi),
-    %(if [ $(CI) = "true" ]; then rm /tmp && mv /tmp.bak /tmp; fi),
+    %(if [ "$(CI)" = "true" ]; then mv /tmp /tmp.bak && ln -s /dev/shm /tmp; fi),
+    %(if [ "$(CI)" = "true" ]; then rm /tmp && mv /tmp.bak /tmp; fi),
   ]]
   Code = %q("linel:99999;print#{E[PREV]};quit();")
 end
@@ -440,6 +440,7 @@ class Ksh_LazyK_Lisaac < CodeGen
     "lisaac qr.li && ./qr > OUTFILE",
   ]
   Apt = ["ksh", nil, "lisaac"]
+  Backup = [nil, nil, "QR.c"]
   def code
     lazyk = ::File.read(::File.join(__dir__, "lazyk-boot.dat"))
     lazyk = lazyk.tr("ski`","0123").scan(/.{1,3}/).map do |n|


### PR DESCRIPTION
This is an amazing project!!

I was able to run it in Ubuntu 20.04 (in VirtualBox on OS X), but I found it much easier to run it in Docker (like done by Travis), so I added a section in the README to explain it (hoping it's easier for newcomers).

Now I realize it might be better to add this section in https://github.com/mame/quine-relay/wiki/Installation
Let me know what you think.

Other minor improvements:
- add the `.curry` directory to `.gitignore`
- take a backup of `QR.c` when running Lisaac, because it causes the SHA1SUM to be wrong for `QC.c` (overwritten by Lisaac)
- add quotes to the `$(CI)` environment variable check, as it causes the condition to be invalid when the variable is not defined.
