### PR TITLE
Keep spoiler history instead of force-pushing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,8 @@ jobs:
           sudo docker run --privileged --name qr -e CI=true -t quine-relay
       - name: push spoiler
         run: |
-          mkdir spoiler
+          git clone https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/mame/quine-relay.git spoiler --branch spoiler
+          git -C spoiler rm --quiet -r '*'
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rb spoiler/
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rs spoiler/
           sudo docker cp qr:/usr/local/share/quine-relay/QR.scala spoiler/
@@ -146,12 +147,12 @@ jobs:
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rc spoiler/
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rexx spoiler/
           cd spoiler
-          git init --quiet
           git config user.name 'Yusuke Endoh'
           git config user.email 'mame@ruby-lang.org'
           git add .
-          git commit -m spoiler --quiet
-          git push --force --quiet https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/mame/quine-relay.git master:spoiler
+          TZ=Asia/Tokyo \
+          git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
+          git push --quiet origin spoiler
           echo The intermediate sources are available: https://github.com/mame/quine-relay/tree/spoiler
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           sudo docker run --privileged --name qr -e CI=true -t quine-relay
       - name: push spoiler
         run: |
-          git clone https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/mame/quine-relay.git spoiler --branch spoiler
+          git clone https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git spoiler --branch spoiler
           git -C spoiler rm --quiet -r '*'
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rb spoiler/
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rs spoiler/
@@ -147,13 +147,16 @@ jobs:
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rc spoiler/
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rexx spoiler/
           cd spoiler
-          git config user.name 'Yusuke Endoh'
-          git config user.email 'mame@ruby-lang.org'
           git add .
-          TZ=Asia/Tokyo \
+          GIT_AUTHOR_NAME="$(git show -s --format=%an "$GITHUB_SHA")" \
+          GIT_AUTHOR_EMAIL="$(git show -s --format=%ae "$GITHUB_SHA")" \
+          GIT_AUTHOR_DATE="$(git show -s --format=%ad "$GITHUB_SHA")" \
+          GIT_COMMITTER_NAME='GitHub Actions' \
+          GIT_COMMITTER_EMAIL='actions@github.com' \
+          TZ=UTC \
           git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
           git push --quiet origin spoiler
-          echo The intermediate sources are available: https://github.com/mame/quine-relay/tree/spoiler
+          echo The intermediate sources are available: https://github.com/${GITHUB_REPOSITORY}/tree/spoiler
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/dot.github.workflows.main.yml.gen.rb
+++ b/src/dot.github.workflows.main.yml.gen.rb
@@ -30,15 +30,16 @@ jobs:
           sudo docker run --privileged --name qr -e CI=true -t quine-relay
       - name: push spoiler
         run: |
-          mkdir spoiler
+          git clone https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/mame/quine-relay.git spoiler --branch spoiler
+          git -C spoiler rm --quiet -r '*'
 #{ cp_cmds }
           cd spoiler
-          git init --quiet
           git config user.name 'Yusuke Endoh'
           git config user.email 'mame@ruby-lang.org'
           git add .
-          git commit -m spoiler --quiet
-          git push --force --quiet https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/mame/quine-relay.git master:spoiler
+          TZ=Asia/Tokyo \
+          git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
+          git push --quiet origin spoiler
           echo The intermediate sources are available: https://github.com/mame/quine-relay/tree/spoiler
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:

--- a/src/dot.github.workflows.main.yml.gen.rb
+++ b/src/dot.github.workflows.main.yml.gen.rb
@@ -30,17 +30,20 @@ jobs:
           sudo docker run --privileged --name qr -e CI=true -t quine-relay
       - name: push spoiler
         run: |
-          git clone https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/mame/quine-relay.git spoiler --branch spoiler
+          git clone https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git spoiler --branch spoiler
           git -C spoiler rm --quiet -r '*'
 #{ cp_cmds }
           cd spoiler
-          git config user.name 'Yusuke Endoh'
-          git config user.email 'mame@ruby-lang.org'
           git add .
-          TZ=Asia/Tokyo \
+          GIT_AUTHOR_NAME="$(git show -s --format=%an "$GITHUB_SHA")" \
+          GIT_AUTHOR_EMAIL="$(git show -s --format=%ae "$GITHUB_SHA")" \
+          GIT_AUTHOR_DATE="$(git show -s --format=%ad "$GITHUB_SHA")" \
+          GIT_COMMITTER_NAME='GitHub Actions' \
+          GIT_COMMITTER_EMAIL='actions@github.com' \
+          TZ=UTC \
           git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
           git push --quiet origin spoiler
-          echo The intermediate sources are available: https://github.com/mame/quine-relay/tree/spoiler
+          echo The intermediate sources are available: https://github.com/${GITHUB_REPOSITORY}/tree/spoiler
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have found that it is difficult to reproduce old versions of quine-relay, even with the Dockerfile, because of unsupported Ubuntu versions and changing package versions. Even when I get it to work, it takes a very long time to run for all commits. The spoiler branch already has these build artifacts, so why doesn't it work? Well, it's force-pushed by GitHub Actions every time a change is pushed to master, so there is only the latest version.

With this PR, starting from now, updates to spoiler will simply push, so that the changes to spoiler can be tracked.

Since it was hard-coded to push to your repo, I made it work when run from a fork. Additionally, it will now have a more descriptive commit message and use the author information from the triggering commit and GitHub Actions as the committer.

You can see what this change looks like in the [spoiler](https://github.com/thaliaarchi/quine-relay-spoiler/commits/3a1eb4b36111e3b582d2b13bb6a90b895b190a42) branch of my fork.