### PR TITLE
Fix backslash escaping in heredoc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,13 @@ jobs:
           sudo docker cp qr:/usr/local/share/quine-relay/QR.rexx spoiler/
           cd spoiler
           git add .
-          GIT_AUTHOR_NAME="$(git show -s --format=%an "$GITHUB_SHA")"           GIT_AUTHOR_EMAIL="$(git show -s --format=%ae "$GITHUB_SHA")"           GIT_AUTHOR_DATE="$(git show -s --format=%ad "$GITHUB_SHA")"           GIT_COMMITTER_NAME='GitHub Actions'           GIT_COMMITTER_EMAIL='actions@github.com'           TZ=UTC           git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
+          GIT_AUTHOR_NAME="$(git show -s --format=%an "$GITHUB_SHA")" \
+          GIT_AUTHOR_EMAIL="$(git show -s --format=%ae "$GITHUB_SHA")" \
+          GIT_AUTHOR_DATE="$(git show -s --format=%ad "$GITHUB_SHA")" \
+          GIT_COMMITTER_NAME='GitHub Actions' \
+          GIT_COMMITTER_EMAIL='actions@github.com' \
+          TZ=UTC \
+          git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
           git push --quiet origin spoiler
           echo The intermediate sources are available: https://github.com/${GITHUB_REPOSITORY}/tree/spoiler
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/src/dot.github.workflows.main.yml.gen.rb
+++ b/src/dot.github.workflows.main.yml.gen.rb
@@ -35,12 +35,12 @@ jobs:
 #{ cp_cmds }
           cd spoiler
           git add .
-          GIT_AUTHOR_NAME="$(git show -s --format=%an "$GITHUB_SHA")" \
-          GIT_AUTHOR_EMAIL="$(git show -s --format=%ae "$GITHUB_SHA")" \
-          GIT_AUTHOR_DATE="$(git show -s --format=%ad "$GITHUB_SHA")" \
-          GIT_COMMITTER_NAME='GitHub Actions' \
-          GIT_COMMITTER_EMAIL='actions@github.com' \
-          TZ=UTC \
+          GIT_AUTHOR_NAME="$(git show -s --format=%an "$GITHUB_SHA")" \\
+          GIT_AUTHOR_EMAIL="$(git show -s --format=%ae "$GITHUB_SHA")" \\
+          GIT_AUTHOR_DATE="$(git show -s --format=%ad "$GITHUB_SHA")" \\
+          GIT_COMMITTER_NAME='GitHub Actions' \\
+          GIT_COMMITTER_EMAIL='actions@github.com' \\
+          TZ=UTC \\
           git commit --allow-empty -m "spoiler: $(git show -s --format=%s "$GITHUB_SHA")"
           git push --quiet origin spoiler
           echo The intermediate sources are available: https://github.com/${GITHUB_REPOSITORY}/tree/spoiler


### PR DESCRIPTION
This fixes escaping of `\` in a heredoc that I overlooked in https://github.com/mame/quine-relay/pull/148.